### PR TITLE
Fixes #59

### DIFF
--- a/src/VimeoDotNet.Net45/VimeoDotNet.Net45.csproj
+++ b/src/VimeoDotNet.Net45/VimeoDotNet.Net45.csproj
@@ -299,6 +299,9 @@
     <Compile Include="..\VimeoDotNet\VimeoClient_TextTracks.cs">
       <Link>VimeoClient_TextTracks.cs</Link>
     </Compile>
+    <Compile Include="..\VimeoDotNet\VimeoClient_RateLimit.cs">
+      <Link>VimeoClient_RateLimit.cs</Link>
+    </Compile>
     <Compile Include="..\VimeoDotNet\Models\TextTrack.cs">
       <Link>Models\TextTrack.cs</Link>
     </Compile>

--- a/src/VimeoDotNet.Net451/VimeoDotNet.Net451.csproj
+++ b/src/VimeoDotNet.Net451/VimeoDotNet.Net451.csproj
@@ -299,6 +299,9 @@
     <Compile Include="..\VimeoDotNet\VimeoClient_TextTracks.cs">
       <Link>VimeoClient_TextTracks.cs</Link>
     </Compile>
+    <Compile Include="..\VimeoDotNet\VimeoClient_RateLimit.cs">
+      <Link>VimeoClient_RateLimit.cs</Link>
+    </Compile>
     <Compile Include="..\VimeoDotNet\Models\TextTrack.cs">
       <Link>Models\TextTrack.cs</Link>
     </Compile>

--- a/src/VimeoDotNet.Net452/VimeoDotNet.Net452.csproj
+++ b/src/VimeoDotNet.Net452/VimeoDotNet.Net452.csproj
@@ -298,6 +298,9 @@
     <Compile Include="..\VimeoDotNet\VimeoClient_TextTracks.cs">
       <Link>VimeoClient_TextTracks.cs</Link>
     </Compile>
+    <Compile Include="..\VimeoDotNet\VimeoClient_RateLimit.cs">
+      <Link>VimeoClient_RateLimit.cs</Link>
+    </Compile>
     <Compile Include="..\VimeoDotNet\Models\TextTrack.cs">
       <Link>Models\TextTrack.cs</Link>
     </Compile>

--- a/src/VimeoDotNet.Net46/VimeoDotNet.Net46.csproj
+++ b/src/VimeoDotNet.Net46/VimeoDotNet.Net46.csproj
@@ -299,6 +299,9 @@
     <Compile Include="..\VimeoDotNet\VimeoClient_TextTracks.cs">
       <Link>VimeoClient_TextTracks.cs</Link>
     </Compile>
+    <Compile Include="..\VimeoDotNet\VimeoClient_RateLimit.cs">
+      <Link>VimeoClient_RateLimit.cs</Link>
+    </Compile>
     <Compile Include="..\VimeoDotNet\Models\TextTrack.cs">
       <Link>Models\TextTrack.cs</Link>
     </Compile>

--- a/src/VimeoDotNet/IVimeoClient.cs
+++ b/src/VimeoDotNet/IVimeoClient.cs
@@ -100,5 +100,11 @@ namespace VimeoDotNet
 		// Deleting Videos
 		void DeleteVideo(long clipId);
 		Task DeleteVideoAsync(long clipId);
-    }
+
+		//Rate Limit
+		long RateLimit { get; }
+		long RateLimitRemaining { get; }
+		System.DateTime RateLimitReset { get; }
+		bool RateLimitUpdatingOn { get; set; }
+	}
 }

--- a/src/VimeoDotNet/VimeoClient_Async.cs
+++ b/src/VimeoDotNet/VimeoClient_Async.cs
@@ -374,6 +374,7 @@ namespace VimeoDotNet
 			try
 			{
 				IRestResponse<T> response = await request.ExecuteRequestAsync<T>();
+				UpdateRateLimit(response);
 
 				// if request was successful, return immediately...
 				if (IsSuccessStatusCode(response.StatusCode))
@@ -410,7 +411,7 @@ namespace VimeoDotNet
 			try
 			{
 				IRestResponse response = await request.ExecuteRequestAsync();
-
+				UpdateRateLimit(response);
 				// if request was successful, return immediately...
 				if (IsSuccessStatusCode(response.StatusCode))
 				{

--- a/src/VimeoDotNet/VimeoClient_RateLimit.cs
+++ b/src/VimeoDotNet/VimeoClient_RateLimit.cs
@@ -1,0 +1,56 @@
+﻿using RestSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using VimeoDotNet.Constants;
+using VimeoDotNet.Enums;
+using VimeoDotNet.Exceptions;
+using VimeoDotNet.Models;
+using VimeoDotNet.Net;
+
+namespace VimeoDotNet
+{
+	public partial class VimeoClient : IVimeoClient
+	{
+		public long RateLimit { get; private set; } = 0;
+		public long RateLimitRemaining { get; private set; } = 0;
+		public DateTime RateLimitReset { get; private set; }
+
+		public bool RateLimitUpdatingOn { get; set; } = false;
+
+		private void UpdateRateLimit(IRestResponse response)
+		{
+			if (!RateLimitUpdatingOn) { return; }
+			try
+			{
+
+			foreach (var header in response.Headers)
+			{
+				switch (header.Name)
+				{
+					case "X-RateLimit-Limit":
+						RateLimit = Convert.ToInt64(header.Value.ToString());
+						break;
+					case "X-RateLimit-Remaining":
+						RateLimitRemaining = Convert.ToInt64(header.Value.ToString());
+						break;
+					case "X-RateLimit-Reset":
+						RateLimitReset = DateTime.Parse(header.Value.ToString());
+						break;
+					default:
+						break;
+				}
+			}
+			} catch (Exception)
+			{
+				// Do not let a failure here break the call
+				RateLimit = 0;
+				RateLimitRemaining = 0;
+				RateLimitReset = DateTime.UtcNow;
+			}
+		}
+	}
+}

--- a/src/VimeoDotNet/VimeoClient_TextTracks.cs
+++ b/src/VimeoDotNet/VimeoClient_TextTracks.cs
@@ -21,6 +21,7 @@ namespace VimeoDotNet
             {
                 IApiRequest request = GenerateTextTracksRequest(clipId);
                 IRestResponse<TextTracks> response = await request.ExecuteRequestAsync<TextTracks>();
+                UpdateRateLimit(response);
                 CheckStatusCodeError(response, "Error retrieving text tracks for video.", HttpStatusCode.NotFound);
 
                 if (response.StatusCode == HttpStatusCode.NotFound)
@@ -45,6 +46,7 @@ namespace VimeoDotNet
             {
                 IApiRequest request = GenerateTextTracksRequest(clipId, trackId);
                 IRestResponse<TextTrack> response = await request.ExecuteRequestAsync<TextTrack>();
+                UpdateRateLimit(response);
                 CheckStatusCodeError(response, "Error retrieving text track for video.", HttpStatusCode.NotFound);
 
                 if (response.StatusCode == HttpStatusCode.NotFound)
@@ -85,6 +87,7 @@ namespace VimeoDotNet
             request.BinaryContent = await fileContent.ReadAllAsync();
 
             IRestResponse response = await request.ExecuteRequestAsync();
+            UpdateRateLimit(response);
             CheckStatusCodeError(null, response, "Error uploading text track file.", HttpStatusCode.BadRequest);
 
             return ticket;
@@ -96,6 +99,7 @@ namespace VimeoDotNet
             {
                 IApiRequest request = GenerateUpdateTextTrackRequest(clipId, trackId, track);
                 IRestResponse<TextTrack> response = await request.ExecuteRequestAsync<TextTrack>();
+                UpdateRateLimit(response);
                 CheckStatusCodeError(response, "Error updating text track for video.", HttpStatusCode.NotFound);
 
                 if (response.StatusCode == HttpStatusCode.NotFound)
@@ -120,6 +124,7 @@ namespace VimeoDotNet
             {
                 IApiRequest request = GenerateDeleteTextTrackRequest(clipId, trackId);
                 IRestResponse<TextTrack> response = await request.ExecuteRequestAsync<TextTrack>();
+                UpdateRateLimit(response);
                 CheckStatusCodeError(response, "Error updating text track for video.", HttpStatusCode.NotFound);
             }
             catch (Exception ex)
@@ -139,6 +144,7 @@ namespace VimeoDotNet
                 IApiRequest request = GenerateUploadTextTrackTicketRequest(clipId, track);
 
                 IRestResponse<TextTrack> response = await request.ExecuteRequestAsync<TextTrack>();
+                UpdateRateLimit(response);
                 CheckStatusCodeError(null, response, "Error generating upload text track ticket.");
 
                 return response.Data;

--- a/src/VimeoDotNet/VimeoClient_Upload.cs
+++ b/src/VimeoDotNet/VimeoClient_Upload.cs
@@ -22,6 +22,7 @@ namespace VimeoDotNet
             {
                 IApiRequest request = GenerateCompleteUploadRequest(uploadRequest.Ticket);
                 IRestResponse response = await request.ExecuteRequestAsync();
+                UpdateRateLimit(response);
                 CheckStatusCodeError(uploadRequest, response, "Error marking file upload as complete.");
 
                 Parameter locationHeader =
@@ -58,6 +59,7 @@ namespace VimeoDotNet
                 IApiRequest request = await GenerateFileStreamRequest(uploadRequest.File, uploadRequest.Ticket,
                     chunkSize: uploadRequest.ChunkSize, written: uploadRequest.BytesWritten);
                 IRestResponse response = await request.ExecuteRequestAsync();
+                UpdateRateLimit(response);
                 CheckStatusCodeError(uploadRequest, response, "Error uploading file chunk.", HttpStatusCode.BadRequest);
 
                 if (response.StatusCode == HttpStatusCode.BadRequest)
@@ -91,6 +93,7 @@ namespace VimeoDotNet
             {
                 IApiRequest request = GenerateUploadTicketRequest();
                 IRestResponse<UploadTicket> response = await request.ExecuteRequestAsync<UploadTicket>();
+                UpdateRateLimit(response);
                 CheckStatusCodeError(null, response, "Error generating upload ticket.");
 
                 return response.Data;
@@ -111,6 +114,7 @@ namespace VimeoDotNet
             {
                 IApiRequest request = GenerateReplaceVideoUploadTicketRequest(videoId);
                 IRestResponse<UploadTicket> response = await request.ExecuteRequestAsync<UploadTicket>();
+                UpdateRateLimit(response);
                 CheckStatusCodeError(null, response, "Error generating upload ticket to replace video.");
 
                 return response.Data;
@@ -199,6 +203,7 @@ namespace VimeoDotNet
                 IApiRequest request =
                     await GenerateFileStreamRequest(uploadRequest.File, uploadRequest.Ticket, verifyOnly: true);
                 IRestResponse response = await request.ExecuteRequestAsync();
+                UpdateRateLimit(response);
                 var verify = new VerifyUploadResponse();
                 CheckStatusCodeError(uploadRequest, response, "Error verifying file upload.", (HttpStatusCode)308);
 

--- a/src/VimeoDotNet/VimeoClient_Videos.cs
+++ b/src/VimeoDotNet/VimeoClient_Videos.cs
@@ -19,6 +19,7 @@ namespace VimeoDotNet
             {
                 IApiRequest request = GenerateVideoDeleteRequest(clipId);
                 IRestResponse response = await request.ExecuteRequestAsync();
+                UpdateRateLimit(response);
                 CheckStatusCodeError(response, "Error deleting video.");
             }
             catch (Exception ex)
@@ -37,6 +38,7 @@ namespace VimeoDotNet
             {
                 IApiRequest request = GenerateAlbumVideosRequest(albumId, clipId: clipId);
                 IRestResponse<Video> response = await request.ExecuteRequestAsync<Video>();
+                UpdateRateLimit(response);
                 CheckStatusCodeError(response, "Error retrieving user album video.", HttpStatusCode.NotFound);
 
                 if (response.StatusCode == HttpStatusCode.NotFound)
@@ -67,6 +69,7 @@ namespace VimeoDotNet
             {
                 IApiRequest request = GenerateAlbumVideosRequest(albumId, page: page, perPage: perPage, sort: sort, direction: direction);
                 IRestResponse<Paginated<Video>> response = await request.ExecuteRequestAsync<Paginated<Video>>();
+                UpdateRateLimit(response);
                 CheckStatusCodeError(response, "Error retrieving account album videos.", HttpStatusCode.NotFound);
 
                 if (response.StatusCode == HttpStatusCode.NotFound)
@@ -96,6 +99,7 @@ namespace VimeoDotNet
             {
                 IApiRequest request = GenerateAlbumVideosRequest(albumId, userId, clipId);
                 IRestResponse<Video> response = await request.ExecuteRequestAsync<Video>();
+                UpdateRateLimit(response);
                 CheckStatusCodeError(response, "Error retrieving user album video.", HttpStatusCode.NotFound);
 
                 if (response.StatusCode == HttpStatusCode.NotFound)
@@ -120,6 +124,7 @@ namespace VimeoDotNet
             {
                 IApiRequest request = GenerateAlbumVideosRequest(albumId, userId);
                 IRestResponse<Paginated<Video>> response = await request.ExecuteRequestAsync<Paginated<Video>>();
+                UpdateRateLimit(response);
                 CheckStatusCodeError(response, "Error retrieving user album videos.", HttpStatusCode.NotFound);
 
                 if (response.StatusCode == HttpStatusCode.NotFound)
@@ -149,6 +154,7 @@ namespace VimeoDotNet
             {
                 IApiRequest request = GenerateVideosRequest(userId, clipId);
                 IRestResponse<Video> response = await request.ExecuteRequestAsync<Video>();
+                UpdateRateLimit(response);
                 CheckStatusCodeError(response, "Error retrieving user video.", HttpStatusCode.NotFound);
 
                 if (response.StatusCode == HttpStatusCode.NotFound)
@@ -178,6 +184,7 @@ namespace VimeoDotNet
             {
                 IApiRequest request = GenerateVideosRequest(userId: userId, page: page, perPage: perPage, query: query);
                 IRestResponse<Paginated<Video>> response = await request.ExecuteRequestAsync<Paginated<Video>>();
+                UpdateRateLimit(response);
                 CheckStatusCodeError(response, "Error retrieving user videos.", HttpStatusCode.NotFound);
 
                 if (response.StatusCode == HttpStatusCode.NotFound)
@@ -207,6 +214,7 @@ namespace VimeoDotNet
             {
                 IApiRequest request = GenerateVideosRequest(clipId: clipId);
                 IRestResponse<Video> response = await request.ExecuteRequestAsync<Video>();
+                UpdateRateLimit(response);
                 CheckStatusCodeError(response, "Error retrieving account video.", HttpStatusCode.NotFound);
 
                 if (response.StatusCode == HttpStatusCode.NotFound)
@@ -231,6 +239,7 @@ namespace VimeoDotNet
             {
                 IApiRequest request = GenerateVideosRequest(page: page, perPage: perPage);
                 IRestResponse<Paginated<Video>> response = await request.ExecuteRequestAsync<Paginated<Video>>();
+                UpdateRateLimit(response);
                 CheckStatusCodeError(response, "Error retrieving account videos.");
 
                 return response.Data;
@@ -251,6 +260,7 @@ namespace VimeoDotNet
             {
                 IApiRequest request = GenerateVideoPatchRequest(clipId, metaData);
                 IRestResponse response = await request.ExecuteRequestAsync();
+                UpdateRateLimit(response);
                 CheckStatusCodeError(response, "Error updating user video metadata.");
             }
             catch (Exception ex)
@@ -269,6 +279,7 @@ namespace VimeoDotNet
             {
                 IApiRequest request = GenerateVideoAllowedDomainPatchRequest(clipId, domain);
                 IRestResponse response = await request.ExecuteRequestAsync();
+                UpdateRateLimit(response);
                 CheckStatusCodeError(response, "Error updating user video allowed domain.");
             }
             catch (Exception ex)

--- a/src/VimeoDotNet/VimeoDotNet.csproj
+++ b/src/VimeoDotNet/VimeoDotNet.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="VimeoClient_RateLimit.cs" />
     <Compile Include="VimeoClient_TextTracks.cs" />
     <Compile Include="VimeoClient_Videos.cs" />
     <Compile Include="VimeoClient_Upload.cs" />


### PR DESCRIPTION
Four properties have been added to IVimeoClient for this.
- RateLimit - Api call limit
- RateLimitRemaining - # of api calls that remain out of the limit
- RateLimitReset - DateTime with the limit will be reset
- RateLimitUpdatingOn - Whether or not these values should be updated from the headers returned in each api call. By default this is "false" if set to true then the hearders are searched for the rate limit information and the properties updated. I added this boolean so users that were not interested in the rate limit information did not have to suffer a performace hit on each api call.
